### PR TITLE
Fix empty split bug

### DIFF
--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -27,7 +27,7 @@
   <name>Feign Benchmark (JMH)</name>
 
   <properties>
-    <jmh.version>1.36</jmh.version>
+    <jmh.version>1.37</jmh.version>
     <rx.netty.version>0.5.3</rx.netty.version>
     <rx.java.version>1.3.8</rx.java.version>
     <netty.version>4.1.96.Final</netty.version>

--- a/core/src/main/java/feign/template/Expressions.java
+++ b/core/src/main/java/feign/template/Expressions.java
@@ -80,8 +80,8 @@ public final class Expressions {
       /* we have a valid variable expression, extract the name from the first group */
       variableName = matcher.group(3).trim();
       if (variableName.contains(":")) {
-        /* split on the colon */
-        String[] parts = variableName.split(":");
+        /* split on the colon and ensure the size of parts array must be 2 */
+        String[] parts = variableName.split(":", 2);
         variableName = parts[0];
         variablePattern = parts[1];
       }

--- a/core/src/main/java/feign/template/Expressions.java
+++ b/core/src/main/java/feign/template/Expressions.java
@@ -22,6 +22,8 @@ import java.util.regex.Pattern;
 
 public final class Expressions {
 
+  private static final int MAX_EXPRESSION_LENGTH = 10000;
+
   private static final String PATH_STYLE_OPERATOR = ";";
   /**
    * Literals may be present and preceded the expression.
@@ -66,6 +68,12 @@ public final class Expressions {
     final String expression = stripBraces(value);
     if (expression == null || expression.isEmpty()) {
       throw new IllegalArgumentException("an expression is required.");
+    }
+
+    /* Check if the expression is too long */
+    if (expression.length() > MAX_EXPRESSION_LENGTH) {
+      throw new IllegalArgumentException(
+          "expression is too long. Max length: " + MAX_EXPRESSION_LENGTH);
     }
 
     /* create a new regular expression matcher for the expression */

--- a/core/src/test/java/feign/template/ExpressionsTest.java
+++ b/core/src/test/java/feign/template/ExpressionsTest.java
@@ -16,6 +16,7 @@ package feign.template;
 import org.junit.jupiter.api.Test;
 import java.util.Collections;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatObject;
 
 public class ExpressionsTest {
 
@@ -25,6 +26,19 @@ public class ExpressionsTest {
     assertThat(expression).isNotNull();
     String expanded = expression.expand(Collections.singletonMap("foo", "bar"), false);
     assertThat(expanded).isEqualToIgnoringCase("foo=bar");
+  }
+
+  @Test
+  public void malformedExpression() {
+    String[] malformedStrings = {"{:}", "{str1:}", "{str1:{:}", "{str1:{str2:}"};
+
+    for (String malformed : malformedStrings) {
+      try {
+        Expressions.create(malformed);
+      } catch (Exception e) {
+        assertThatObject(e).isNotInstanceOf(ArrayIndexOutOfBoundsException.class);
+      }
+    }
   }
 
   @Test

--- a/core/src/test/java/feign/template/ExpressionsTest.java
+++ b/core/src/test/java/feign/template/ExpressionsTest.java
@@ -40,7 +40,7 @@ public class ExpressionsTest {
       }
     }
   }
-  
+
   @Test
   public void malformedBodyTemplate() {
     String bodyTemplate = "{" + "a".repeat(65536) + "}";

--- a/core/src/test/java/feign/template/ExpressionsTest.java
+++ b/core/src/test/java/feign/template/ExpressionsTest.java
@@ -16,6 +16,7 @@ package feign.template;
 import org.junit.jupiter.api.Test;
 import java.util.Collections;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatObject;
 
 public class ExpressionsTest {
 
@@ -25,6 +26,17 @@ public class ExpressionsTest {
     assertThat(expression).isNotNull();
     String expanded = expression.expand(Collections.singletonMap("foo", "bar"), false);
     assertThat(expanded).isEqualToIgnoringCase("foo=bar");
+  }
+
+  @Test
+  public void malformedBodyTemplate() {
+    String bodyTemplate = "{" + "a".repeat(65536) + "}";
+
+    try {
+      BodyTemplate template = BodyTemplate.create(bodyTemplate);
+    } catch (Throwable e) {
+      assertThatObject(e).isNotInstanceOf(StackOverflowError.class);
+    }
   }
 
   @Test

--- a/jaxb/README.md
+++ b/jaxb/README.md
@@ -25,3 +25,17 @@ JAXBDecoder jaxbDecoder = new JAXBDecoder.Builder()
     .withNamespaceAware(false) // true by default
     .build();
 ```
+
+Usage
+===================
+
+The feign library is available from [Maven Central](https://mvnrepository.com/artifact/io.github.openfeign/feign-jaxb).
+
+```xml
+<dependency>
+    <groupId>io.github.openfeign</groupId>
+    <artifactId>feign-jaxb</artifactId>
+    <version>??feing-jaxb-version??</version>
+</dependency>
+
+```


### PR DESCRIPTION
This fixes an ArrayIndexOutOfBoundException in Expressions.java.

If the `String.split(regex)` method is called without providing the limit parameter, it has the same behaviour as `String.split(regex, 0)` in which the limit is default to 0. As mentioned in the JDK javadoc, if the limit is set to 0, all trailing empty string in the split result will be discarded. For example, `"A::A".split(":")` will result in `["A", "", "A"]` correctly, but `A::".split(":")` will result in `["A"]` because the two trailing empty string is discarded. If the string only contains the split character, it will even result in an empty array. For example, `"::".split(":")`  will result in `[]` because the 3 empty strings are discarded. Because of this reason, if the provided variableName contains only `":"` characters, it will result in ArrayIndexOutOfBoundException in the next line. Also, if the provided variableName contains only 1 `":"` characters and end with it, parts[1] will also result in ArrayIndexOutOfBoundException.

This PR fixes the possible ArrayIndexOutOfBoundException by adding the limit 2 to the split method call. With the limit set, it is guaranteed to have a result String array with size equal to the limit if ":" split character does exist. This setting should avoid the possible ArrayIndexOutOfBoundException. If the string contains an undetermined number of ":" characters, using the limit = -1 can guarantee all the trailing empty strings are not discarded. The size of the resulting String array is guaranteed to be the number of ":" character + 1.

We found this bug using fuzzing by way of OSS-Fuzz, where we recently integrated Feign (https://github.com/google/oss-fuzz/pull/10684). OSS-Fuzz is a free service run by Google for fuzzing important open source software. If you'd like to know more about this then I'm happy to go in details and also set up things so you can receive emails and detailed reports when bugs are found.
